### PR TITLE
JPERF-478: Expose the SSH host via SSH connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ The API consists of all public Kotlin types from `com.atlassian.performance.tool
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/ssh/compare/release-2.2.0...master
 
+### Added
+- Expose the SSH host via SSH connection. Unblock [JPERF-478].
+
+[JPERF-478]: https://ecosystem.atlassian.net/browse/JPERF-478
+
 ## [2.2.0] - 2019-02-27
 [2.2.0]: https://github.com/atlassian/ssh/compare/release-2.1.0...release-2.2.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/ssh/SshjConnection.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/ssh/SshjConnection.kt
@@ -4,6 +4,7 @@ import com.atlassian.performance.tools.io.api.ensureDirectory
 import com.atlassian.performance.tools.ssh.api.DetachedProcess
 import com.atlassian.performance.tools.ssh.api.SshConnection
 import com.atlassian.performance.tools.ssh.api.SshConnection.SshResult
+import com.atlassian.performance.tools.ssh.api.SshHost
 import net.schmizz.sshj.SSHClient
 import net.schmizz.sshj.connection.channel.direct.Session
 import org.apache.logging.log4j.Level
@@ -21,7 +22,7 @@ import java.util.concurrent.TimeUnit
  */
 internal class SshjConnection internal constructor(
     private val ssh: SSHClient,
-    private val username: String
+    private val sshHost: SshHost
 ) : SshConnection {
 
     private val logger: Logger = LogManager.getLogger(this::class.java)
@@ -60,7 +61,7 @@ internal class SshjConnection internal constructor(
         stdout: Level,
         stderr: Level
     ): SshResult {
-        logger.debug("$username$ $cmd")
+        logger.debug("${sshHost.userName}$ $cmd")
         return session.exec(cmd).use { command ->
             command.waitForCompletion(cmd, timeout)
             SshResult(
@@ -136,6 +137,8 @@ internal class SshjConnection internal constructor(
         }
         return output
     }
+
+    override fun getHost(): SshHost = sshHost
 
     override fun close() {
         ssh.close()

--- a/src/main/kotlin/com/atlassian/performance/tools/ssh/api/Ssh.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/ssh/api/Ssh.kt
@@ -39,7 +39,7 @@ data class Ssh(
     fun newConnection(): SshConnection {
         return SshjConnection(
             prepareClient(),
-            host.userName
+            host
         )
     }
 

--- a/src/main/kotlin/com/atlassian/performance/tools/ssh/api/SshConnection.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/ssh/api/SshConnection.kt
@@ -154,6 +154,12 @@ interface SshConnection : Closeable {
     )
 
     /**
+     * @since 2.3.0
+     */
+    @JvmDefault
+    fun getHost(): SshHost = throw Exception("Not implemented")
+
+    /**
      * Holds results of a SSH command.
      *
      * @param exitStatus Holds exit code from a remotely executed SSH command.


### PR DESCRIPTION
The idea is to let `infrastructure.api.os.Ubuntu` maintain locks per SSH host IP.