### PR TITLE
JPERF-729 Add logging ip address of target machine where command is run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The API consists of all public Kotlin types from `com.atlassian.performance.tool
 
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/ssh/compare/release-2.4.0...master
+### Added
+- Add logging ip address of target machine where command is run
 
 ## [2.4.0] - 2021-01-07
 [2.4.0]: https://github.com/atlassian/ssh/compare/release-2.3.1...release-2.4.0

--- a/src/main/kotlin/com/atlassian/performance/tools/ssh/SshjConnection.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/ssh/SshjConnection.kt
@@ -58,7 +58,7 @@ internal class SshjConnection internal constructor(
         stdout: Level,
         stderr: Level
     ): SshResult {
-        logger.debug("${sshHost.userName}$ $cmd")
+        logger.debug("${sshHost.userName}@${sshHost.ipAddress}$ $cmd")
         return session.exec(cmd).use { command ->
             WaitingCommand(command, timeout, stdout, stderr).waitForResult()
         }


### PR DESCRIPTION
It's really hard to read JPT logs without it