### PR TITLE
JPERF-570: clean up log4j deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ The API consists of all public Kotlin types from `com.atlassian.performance.tool
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/ssh/compare/release-2.4.3...master
 
+### Fixed
+- Drop `log4j-core` and `slf4j-impl` from POM. Fix [JPERF-570].
+- Relax `log4j-api` to a SemVer range.
+
+[JPERF-570]: https://ecosystem.atlassian.net/browse/JPERF-570
+
 ## [2.4.3] - 2022-06-23
 [2.4.3]: https://github.com/atlassian/ssh/compare/release-2.4.2...release-2.4.3
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,7 @@ configurations.all {
         eachDependency {
             when (requested.module.toString()) {
                 "org.jetbrains:annotations" -> useVersion("15.0")
-                // conflict between jvm-tasks and sshj
+                // conflict between testcontainers, ssh-ubuntu and sshj
                 "org.slf4j:slf4j-api" -> useVersion("1.7.25")
             }
             when (requested.group) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,8 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val kotlinVersion = "1.2.70"
-val log4jVersion = "2.17.1"
+val log4jVersion = "[2.0.0, 2.999.999)"
+val log4jGroup = "org.apache.logging.log4j"
 
 plugins {
     kotlin("jvm").version("1.2.70")
@@ -14,12 +15,14 @@ configurations.all {
         failOnVersionConflict()
         eachDependency {
             when (requested.module.toString()) {
-                "org.slf4j:slf4j-api" -> useVersion("1.8.0-alpha2")
                 "org.jetbrains:annotations" -> useVersion("15.0")
+                // conflict between jvm-tasks and sshj
+                "org.slf4j:slf4j-api" -> useVersion("1.7.25")
             }
             when (requested.group) {
                 "org.jetbrains.kotlin" -> useVersion(kotlinVersion)
-                "org.apache.logging.log4j" -> useVersion(log4jVersion)
+                // conflict between jvm-tasks and ssh-ubuntu
+                log4jGroup -> useVersion(log4jVersion)
             }
         }
     }
@@ -31,11 +34,8 @@ dependencies {
     compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVersion")
     compile("org.glassfish:javax.json:1.1")
     compile("com.hierynomus:sshj:0.23.0")
-    listOf(
-        "api",
-        "core",
-        "slf4j-impl"
-    ).forEach { compile("org.apache.logging.log4j:log4j-$it:$log4jVersion") }
+    api("$log4jGroup:log4j-api:$log4jVersion")
+    testImplementation("$log4jGroup:log4j-core:$log4jVersion")
     testCompile("junit:junit:4.12")
     testCompile("com.atlassian.performance.tools:ssh-ubuntu:0.1.0")
 }

--- a/gradle/dependency-locks/apiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/apiDependenciesMetadata.lockfile
@@ -2,13 +2,11 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
 org.apache.logging.log4j:log4j-api:2.20.0
-org.apache.logging.log4j:log4j-core:2.20.0
-org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1

--- a/gradle/dependency-locks/apiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/apiDependenciesMetadata.lockfile
@@ -2,21 +2,19 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
-org.apache.logging.log4j:log4j-api:2.17.1
-org.apache.logging.log4j:log4j-core:2.17.1
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+org.apache.logging.log4j:log4j-api:2.20.0
+org.apache.logging.log4j:log4j-core:2.20.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
-org.slf4j:slf4j-api:1.8.0-alpha2
+org.slf4j:slf4j-api:1.7.25

--- a/gradle/dependency-locks/compile.lockfile
+++ b/gradle/dependency-locks/compile.lockfile
@@ -2,13 +2,11 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
 org.apache.logging.log4j:log4j-api:2.20.0
-org.apache.logging.log4j:log4j-core:2.20.0
-org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1

--- a/gradle/dependency-locks/compile.lockfile
+++ b/gradle/dependency-locks/compile.lockfile
@@ -2,21 +2,19 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
-org.apache.logging.log4j:log4j-api:2.17.1
-org.apache.logging.log4j:log4j-core:2.17.1
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+org.apache.logging.log4j:log4j-api:2.20.0
+org.apache.logging.log4j:log4j-core:2.20.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
-org.slf4j:slf4j-api:1.8.0-alpha2
+org.slf4j:slf4j-api:1.7.25

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,13 +2,11 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
 org.apache.logging.log4j:log4j-api:2.20.0
-org.apache.logging.log4j:log4j-core:2.20.0
-org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,21 +2,19 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
-org.apache.logging.log4j:log4j-api:2.17.1
-org.apache.logging.log4j:log4j-core:2.17.1
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+org.apache.logging.log4j:log4j-api:2.20.0
+org.apache.logging.log4j:log4j-core:2.20.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
-org.slf4j:slf4j-api:1.8.0-alpha2
+org.slf4j:slf4j-api:1.7.25

--- a/gradle/dependency-locks/default.lockfile
+++ b/gradle/dependency-locks/default.lockfile
@@ -2,13 +2,11 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
 org.apache.logging.log4j:log4j-api:2.20.0
-org.apache.logging.log4j:log4j-core:2.20.0
-org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1

--- a/gradle/dependency-locks/default.lockfile
+++ b/gradle/dependency-locks/default.lockfile
@@ -2,21 +2,19 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
-org.apache.logging.log4j:log4j-api:2.17.1
-org.apache.logging.log4j:log4j-core:2.17.1
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+org.apache.logging.log4j:log4j-api:2.20.0
+org.apache.logging.log4j:log4j-core:2.20.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
-org.slf4j:slf4j-api:1.8.0-alpha2
+org.slf4j:slf4j-api:1.7.25

--- a/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -2,13 +2,11 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
 org.apache.logging.log4j:log4j-api:2.20.0
-org.apache.logging.log4j:log4j-core:2.20.0
-org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1

--- a/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -2,21 +2,19 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
-org.apache.logging.log4j:log4j-api:2.17.1
-org.apache.logging.log4j:log4j-core:2.17.1
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+org.apache.logging.log4j:log4j-api:2.20.0
+org.apache.logging.log4j:log4j-core:2.20.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
-org.slf4j:slf4j-api:1.8.0-alpha2
+org.slf4j:slf4j-api:1.7.25

--- a/gradle/dependency-locks/runtime.lockfile
+++ b/gradle/dependency-locks/runtime.lockfile
@@ -2,13 +2,11 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
 org.apache.logging.log4j:log4j-api:2.20.0
-org.apache.logging.log4j:log4j-core:2.20.0
-org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1

--- a/gradle/dependency-locks/runtime.lockfile
+++ b/gradle/dependency-locks/runtime.lockfile
@@ -2,21 +2,19 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
-org.apache.logging.log4j:log4j-api:2.17.1
-org.apache.logging.log4j:log4j-core:2.17.1
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+org.apache.logging.log4j:log4j-api:2.20.0
+org.apache.logging.log4j:log4j-core:2.20.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
-org.slf4j:slf4j-api:1.8.0-alpha2
+org.slf4j:slf4j-api:1.7.25

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -2,13 +2,11 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
 org.apache.logging.log4j:log4j-api:2.20.0
-org.apache.logging.log4j:log4j-core:2.20.0
-org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -2,21 +2,19 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 net.i2p.crypto:eddsa:0.2.0
-org.apache.logging.log4j:log4j-api:2.17.1
-org.apache.logging.log4j:log4j-core:2.17.1
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+org.apache.logging.log4j:log4j-api:2.20.0
+org.apache.logging.log4j:log4j-core:2.20.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
-org.slf4j:slf4j-api:1.8.0-alpha2
+org.slf4j:slf4j-api:1.7.25

--- a/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
@@ -16,9 +16,9 @@ net.i2p.crypto:eddsa:0.2.0
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
 org.apache.commons:commons-compress:1.18
-org.apache.logging.log4j:log4j-api:2.17.1
-org.apache.logging.log4j:log4j-core:2.17.1
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+org.apache.logging.log4j:log4j-api:2.20.0
+org.apache.logging.log4j:log4j-core:2.20.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1
@@ -26,13 +26,11 @@ org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2
 org.scijava:native-lib-loader:2.0.2
-org.slf4j:slf4j-api:1.8.0-alpha2
+org.slf4j:slf4j-api:1.7.25
 org.testcontainers:testcontainers:1.10.5

--- a/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3

--- a/gradle/dependency-locks/testCompile.lockfile
+++ b/gradle/dependency-locks/testCompile.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
@@ -16,9 +16,9 @@ net.i2p.crypto:eddsa:0.2.0
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
 org.apache.commons:commons-compress:1.18
-org.apache.logging.log4j:log4j-api:2.17.1
-org.apache.logging.log4j:log4j-core:2.17.1
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+org.apache.logging.log4j:log4j-api:2.20.0
+org.apache.logging.log4j:log4j-core:2.20.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1
@@ -26,13 +26,11 @@ org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2
 org.scijava:native-lib-loader:2.0.2
-org.slf4j:slf4j-api:1.8.0-alpha2
+org.slf4j:slf4j-api:1.7.25
 org.testcontainers:testcontainers:1.10.5

--- a/gradle/dependency-locks/testCompile.lockfile
+++ b/gradle/dependency-locks/testCompile.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
@@ -10,7 +10,6 @@ junit:junit:4.12
 net.i2p.crypto:eddsa:0.2.0
 org.apache.logging.log4j:log4j-api:2.20.0
 org.apache.logging.log4j:log4j-core:2.20.0
-org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -2,15 +2,15 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
 junit:junit:4.12
 net.i2p.crypto:eddsa:0.2.0
-org.apache.logging.log4j:log4j-api:2.17.1
-org.apache.logging.log4j:log4j-core:2.17.1
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+org.apache.logging.log4j:log4j-api:2.20.0
+org.apache.logging.log4j:log4j-core:2.20.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1
@@ -18,8 +18,6 @@ org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
-org.slf4j:slf4j-api:1.8.0-alpha2
+org.slf4j:slf4j-api:1.7.25

--- a/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
@@ -16,9 +16,9 @@ net.i2p.crypto:eddsa:0.2.0
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
 org.apache.commons:commons-compress:1.18
-org.apache.logging.log4j:log4j-api:2.17.1
-org.apache.logging.log4j:log4j-core:2.17.1
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+org.apache.logging.log4j:log4j-api:2.20.0
+org.apache.logging.log4j:log4j-core:2.20.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1
@@ -26,13 +26,11 @@ org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2
 org.scijava:native-lib-loader:2.0.2
-org.slf4j:slf4j-api:1.8.0-alpha2
+org.slf4j:slf4j-api:1.7.25
 org.testcontainers:testcontainers:1.10.5

--- a/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3

--- a/gradle/dependency-locks/testRuntime.lockfile
+++ b/gradle/dependency-locks/testRuntime.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
@@ -16,9 +16,9 @@ net.i2p.crypto:eddsa:0.2.0
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
 org.apache.commons:commons-compress:1.18
-org.apache.logging.log4j:log4j-api:2.17.1
-org.apache.logging.log4j:log4j-core:2.17.1
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+org.apache.logging.log4j:log4j-api:2.20.0
+org.apache.logging.log4j:log4j-core:2.20.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1
@@ -26,13 +26,11 @@ org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2
 org.scijava:native-lib-loader:2.0.2
-org.slf4j:slf4j-api:1.8.0-alpha2
+org.slf4j:slf4j-api:1.7.25
 org.testcontainers:testcontainers:1.10.5

--- a/gradle/dependency-locks/testRuntime.lockfile
+++ b/gradle/dependency-locks/testRuntime.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.2.3
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3
@@ -16,9 +16,9 @@ net.i2p.crypto:eddsa:0.2.0
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
 org.apache.commons:commons-compress:1.18
-org.apache.logging.log4j:log4j-api:2.17.1
-org.apache.logging.log4j:log4j-core:2.17.1
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
+org.apache.logging.log4j:log4j-api:2.20.0
+org.apache.logging.log4j:log4j-core:2.20.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.20.0
 org.bouncycastle:bcpkix-jdk15on:1.56
 org.bouncycastle:bcprov-jdk15on:1.56
 org.glassfish:javax.json:1.1
@@ -26,13 +26,11 @@ org.hamcrest:hamcrest-core:1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
-org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:15.0
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2
 org.scijava:native-lib-loader:2.0.2
-org.slf4j:slf4j-api:1.8.0-alpha2
+org.slf4j:slf4j-api:1.7.25
 org.testcontainers:testcontainers:1.10.5

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.2.3
+com.atlassian.performance.tools:jvm-tasks:1.2.4
 com.atlassian.performance.tools:ssh-ubuntu:0.1.0
 com.hierynomus:sshj:0.23.0
 com.jcraft:jzlib:1.1.3


### PR DESCRIPTION
Yes, log4j-api is part of ssh API: `SshConnection.execute(..., Level)`.

Also, harvest log4j fix from jvm-tasks:1.2.4. It only cleans up local locks. It has no bearing on the POM.